### PR TITLE
Replace object hash map with avl-tree

### DIFF
--- a/jzon.h
+++ b/jzon.h
@@ -37,15 +37,12 @@ struct jzon {
     };
 };
 
-struct jzon_member {
+struct jzon_object {
     char *key;
     struct jzon *value;
-};
-
-struct jzon_object {
-    int capacity;
-    int size;
-    struct jzon_member *members;
+    int height;
+    struct jzon_object *left;
+    struct jzon_object *right;
 };
 
 struct jzon_array {

--- a/object.c
+++ b/object.c
@@ -6,23 +6,68 @@
 void jzon_free(struct jzon *value);
 void set_error(enum jzon_error_type error, const char *fmt, ...);
 void *jzon_calloc(size_t count, size_t size);
+char *jzon_strdup(const char *s1);
 
-unsigned long hash(const char *str)
+static int max(int lhs, int rhs)
 {
-    unsigned long hash = 5381;
-    int c;
-
-    while ((c = *str++)) {
-        hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
-    }
-
-    return hash;
+    return lhs > rhs ? lhs : rhs;
 }
 
-struct jzon_object *object_create(int capacity)
+static int height(struct jzon_object *object)
 {
-    if (capacity <= 0) {
-        set_error(JZONE_INVAL, "object_create: %s", "Invalid capacity");
+    if (!object) {
+        return 0;
+    }
+
+    return object->height;
+}
+
+static int balance(struct jzon_object *object)
+{
+    if (!object) {
+        return 0;
+    }
+
+    return height(object->left) - height(object->right);
+}
+
+static struct jzon_object *rotate_left(struct jzon_object *object)
+{
+    struct jzon_object *right = object->right;
+    struct jzon_object *left = right->left;
+
+    right->left = object;
+    object->right = left;
+
+    object->height = max(height(object->left), height(object->right)) + 1;
+    right->height = max(height(right->left), height(right->right)) + 1;
+
+    return right;
+}
+
+static struct jzon_object *rotate_right(struct jzon_object *object)
+{
+    struct jzon_object *left = object->left;
+    struct jzon_object *right = left->right;
+
+    left->right = object;
+    object->left = right;
+
+    object->height = max(height(object->left), height(object->right)) + 1;
+    left->height = max(height(left->left), height(left->right)) + 1;
+
+    return left;
+}
+
+static struct jzon_object *object_create(const char *key, struct jzon *value)
+{
+    if (!key) {
+        set_error(JZONE_INVAL, "object_create: %s", "No key is given");
+        return NULL;
+    }
+
+    if (!value) {
+        set_error(JZONE_INVAL, "object_create: %s", "No value is given");
         return NULL;
     }
 
@@ -31,98 +76,118 @@ struct jzon_object *object_create(int capacity)
         return NULL;
     }
 
-    object->capacity = capacity + 1;
-    object->size = 0;
-    object->members = jzon_calloc(object->capacity, sizeof(struct jzon_member));
-    if (!object->members) {
+    object->key = jzon_strdup(key);
+    if (!object->key) {
         free(object);
         return NULL;
     }
 
-    for (int i = 0; i < object->capacity; i++) {
-        object->members[i].key = NULL;
-        object->members[i].value = NULL;
+    object->value = value;
+    object->height = 1;
+    object->left = NULL;
+    object->right = NULL;
+
+    return object;
+}
+
+struct jzon_object *object_put(struct jzon_object *object, const char *key,
+                               struct jzon *value)
+{
+    if (!key) {
+        set_error(JZONE_INVAL, "object_create: %s", "No key is given");
+        return NULL;
+    }
+
+    if (!value) {
+        set_error(JZONE_INVAL, "object_create: %s", "No value is given");
+        return NULL;
+    }
+
+    if (!object) {
+        return object_create(key, value);
+    }
+
+    int cmp = strcmp(key, object->key);
+    if (cmp == 0) {
+        object->value = value;
+        return object;
+    } else if (cmp < 0) {
+        object->left = object_put(object->left, key, value);
+    } else {
+        object->right = object_put(object->right, key, value);
+    }
+
+    object->height = max(height(object->left), height(object->right)) + 1;
+
+    int b = balance(object);
+
+    /* left left */
+    if (b > 1 && strcmp(key, object->left->key) < 0) {
+        return rotate_right(object);
+    }
+
+    /* left right */
+    if (b > 1 && strcmp(key, object->left->key) > 0) {
+        object->left = rotate_left(object->left);
+        return rotate_right(object);
+    }
+
+    /* right right */
+    if (b < -1 && strcmp(key, object->right->key) > 0) {
+        return rotate_left(object);
+    }
+
+    /* right left */
+    if (b < -1 && strcmp(key, object->right->key) < 0) {
+        object->right = rotate_right(object->right);
+        return rotate_left(object);
     }
 
     return object;
 }
 
-int object_put(struct jzon_object *object, const char *key,
-               struct jzon *value)
-{
-    if (!object || !key) {
-        return -1;
-    }
-
-    unsigned long hashval = hash(key);
-    unsigned long position;
-    unsigned int reassign = 0;
-    int i = 1;
-
-    do {
-        // Quadratic probing
-        position = hashval + ((int)(0.5 * i)) + ((int)(0.5 * i * i));
-        position %= object->capacity;
-        i++;
-    } while (
-        object->members[position].key &&
-        !(reassign = strcmp(object->members[position].key, key) == 0)
-    );
-
-    if (!reassign) {
-        object->size++;
-        object->members[position].key = jzon_calloc(strlen(key) + 1, sizeof(char));
-        if (!object->members[position].key) {
-            return -1;
-        }
-
-        strcpy(object->members[position].key, key);
-    }
-
-    object->members[position].value = value;
-
-    return 0;
-}
-
 struct jzon *object_get(struct jzon_object *object, const char *key)
 {
-    struct jzon *value = NULL;
+    if (!object) {
+        set_error(JZONE_INVAL, "object_get: %s", "No object is given");
+        return NULL;
+    }
 
-    if (object && key) {
-        unsigned long hashval = hash(key);
-        unsigned long position;
-        int i = 1;
+    if (!key) {
+        set_error(JZONE_INVAL, "object_get: %s", "No key is given");
+        return NULL;
+    }
 
-        do {
-            // Quadratic probing
-            position =
-                hashval + ((int)(0.5 * i)) + ((int)(0.5 * i * i));
-            position %= object->capacity;
-            i++;
-        } while (object->members[position].key &&
-                 strcmp(object->members[position].key, key) != 0);
+    struct jzon_object *temp = object;
 
-        if (object->members[position].key) {
-            value = object->members[position].value;
+    while (temp) {
+        int cmp = strcmp(key, temp->key);
+        if (cmp == 0) {
+            return temp->value;
+        } else if (cmp < 0) {
+            temp = temp->left;
+        } else {
+            temp = temp->right;
         }
     }
 
-    return value;
+    return NULL;
 }
 
 void object_free(struct jzon_object *object)
 {
-    if (!object) {
-        return;
-    }
-
-    for (int i = 0; i < object->capacity; i++) {
-        if (object->members[i].key) {
-            free(object->members[i].key);
-            jzon_free(object->members[i].value);
+    if (object) {
+        if (object->left) {
+            object_free(object->left);
         }
-    }
 
-    free(object->members);
-    free(object);
+        if (object->right) {
+            object_free(object->right);
+        }
+
+        free(object->key);
+        jzon_free(object->value);
+
+        free(object);
+    }
 }

--- a/parser.y
+++ b/parser.y
@@ -18,8 +18,8 @@
     struct jzon_object *object_create(int capacity);
     void jzon_free(struct jzon *value);
     struct jzon_array *array_create(int capacity);
-    int object_put(struct jzon_object *object, const char *key,
-                   struct jzon *value);
+    struct jzon_object *object_put(struct jzon_object *object, const char *key,
+        struct jzon *value);
     void set_error(enum jzon_error_type error, const char *fmt, ...);
     void *jzon_calloc(size_t count, size_t size);
     void *jzon_realloc(void *ptr, size_t size);
@@ -131,16 +131,15 @@ start ::= error. {
 }
 
 object(O) ::= LBRACE RBRACE. {
-    O = jzon_calloc(1, sizeof(struct jzon_object));
-    if (O) {
-        O->capacity = 0;
-        O->size = 0;
-    }
+    O = NULL;
 }
 object(O) ::= LBRACE members(M) RBRACE. {
-    O = object_create(M->size);
+    O = object_put(NULL, M->pairs[0]->string, M->pairs[0]->value);
     if (O) {
-        for (int i = 0; i < M->size; i++) {
+        free(M->pairs[0]->string);
+        free(M->pairs[0]);
+
+        for (int i = 1; i < M->size; i++) {
             object_put(O, M->pairs[i]->string, M->pairs[i]->value);
             free(M->pairs[i]->string);
             free(M->pairs[i]);


### PR DESCRIPTION
This PR replaces the hash map implementation of the object with an avl-tree. This has the advantage to insert and find elements by key in O(log(n)). This also fixes the bug from issue #2.